### PR TITLE
動的プレースホルダー

### DIFF
--- a/go/src/app/main.go
+++ b/go/src/app/main.go
@@ -37,7 +37,7 @@ func initDB() {
 		db_password = ":" + db_password
 	}
 
-	dsn := fmt.Sprintf("%s%s@tcp(%s:%s)/isudb?parseTime=true&loc=Local&charset=utf8mb4",
+	dsn := fmt.Sprintf("%s%s@tcp(%s:%s)/isudb?parseTime=true&loc=Local&charset=utf8mb4&interpolateParams=true",
 		db_user, db_password, db_host, db_port)
 
 	log.Printf("Connecting to db: %q", dsn)


### PR DESCRIPTION
#1 

スコア
```
{"job_id":"","ip_addrs":"172.31.8.31","pass":true,"score":5212,"message":"ok","error":null,"log":["09/23 02:52:25 接続数が増加します","09/23 02:52:26 接続数が増加します","09/23 02:52:27 接続数が増加します","09/23 02:52:30 接続数が増加します (上限:25)","09/23 02:52:45 接続数が増加します (上限:25)","09/23 02:52:58 接続数が増加します (上限:25)","09/23 02:53:04 接続数が増加します (上限:25)","09/23 02:53:05 接続数が増加します (上限:25)","09/23 02:53:08 接続数が増加します (上限:25)","09/23 02:53:11 接続数が増加します (上限:25)","09/23 02:53:12 接続数が増加します (上限:25)","09/23 02:53:15 接続数が増加します (上限:25)","09/23 02:53:16 接続数が増加します (上限:25)","09/23 02:53:17 接続数が増加します (上限:25)","09/23 02:53:18 接続数が増加します (上限:25)","09/23 02:53:19 接続数が増加します (上限:25)","09/23 02:53:20 接続数が増加します (上限:25)","09/23 02:53:21 接続数が増加します (上限:25)","09/23 02:53:22 接続数が増加します (上限:25)","09/23 02:53:23 接続数が増加します (上限:25)","09/23 02:53:24 接続数が増加します (上限:25)"],"load_level":3,"start_time":"2023-09-23T02:52:20.723016776Z","end_time":"2023-09-23T02:53:25.493721957Z"}
```


slowlog

```

Reading mysql slow query log from mysql-slow.log
Count: 1  Time=0.04s (0s)  Lock=0.00s (0s)  Rows=0.0 (0), local_user[local_user]@ip-172-31-8-31.ap-northeast-1.compute.internal
  TRUNCATE TABLE room_time

Count: 1  Time=0.03s (0s)  Lock=0.00s (0s)  Rows=0.0 (0), local_user[local_user]@ip-172-31-8-31.ap-northeast-1.compute.internal
  TRUNCATE TABLE buying

Count: 1  Time=0.03s (0s)  Lock=0.00s (0s)  Rows=0.0 (0), local_user[local_user]@ip-172-31-8-31.ap-northeast-1.compute.internal
  TRUNCATE TABLE adding

Count: 7200  Time=0.00s (30s)  Lock=0.00s (0s)  Rows=0.0 (0), local_user[local_user]@ip-172-31-8-31.ap-northeast-1.compute.internal
  COMMIT

Count: 359  Time=0.00s (0s)  Lock=0.00s (0s)  Rows=270.3 (97037), local_user[local_user]@ip-172-31-8-31.ap-northeast-1.compute.internal
  SELECT isu FROM adding WHERE room_name = 'S' AND time <= N

Count: 4887  Time=0.00s (1s)  Lock=0.00s (0s)  Rows=256.8 (1255072), local_user[local_user]@ip-172-31-8-31.ap-northeast-1.compute.internal
  SELECT time, isu FROM adding WHERE room_name = 'S'

Count: 7255  Time=0.00s (1s)  Lock=0.12s (849s)  Rows=0.0 (0), local_user[local_user]@ip-172-31-8-31.ap-northeast-1.compute.internal
  INSERT INTO room_time(room_name, time) VALUES ('S', N) ON DUPLICATE KEY UPDATE time = time

Count: 360  Time=0.00s (0s)  Lock=0.00s (0s)  Rows=1.0 (360), local_user[local_user]@ip-172-31-8-31.ap-northeast-1.compute.internal
  SELECT COUNT(*) FROM buying WHERE room_name = 'S' AND item_id = N

Count: 1954  Time=0.00s (0s)  Lock=0.00s (0s)  Rows=0.0 (0), local_user[local_user]@ip-172-31-8-31.ap-northeast-1.compute.internal
  UPDATE adding SET isu = 'S' WHERE room_name = 'S' AND time = N

Count: 5246  Time=0.00s (0s)  Lock=0.00s (0s)  Rows=42.3 (221670), local_user[local_user]@ip-172-31-8-31.ap-northeast-1.compute.internal
  SELECT item_id, ordinal, time FROM buying WHERE room_name = 'S'

Count: 1954  Time=0.00s (0s)  Lock=0.00s (0s)  Rows=0.0 (0), local_user[local_user]@ip-172-31-8-31.ap-northeast-1.compute.internal
  INSERT INTO adding(room_name, time, isu) VALUES ('S', N, 'S') ON DUPLICATE KEY UPDATE isu=isu

Count: 7201  Time=0.00s (0s)  Lock=0.00s (0s)  Rows=0.0 (0), local_user[local_user]@ip-172-31-8-31.ap-northeast-1.compute.internal
  UPDATE room_time SET time = N WHERE room_name = 'S'

Count: 359  Time=0.00s (0s)  Lock=0.00s (0s)  Rows=0.0 (0), local_user[local_user]@ip-172-31-8-31.ap-northeast-1.compute.internal
  INSERT INTO buying(room_name, item_id, ordinal, time) VALUES('S', N, N, N)

Count: 1954  Time=0.00s (0s)  Lock=0.00s (0s)  Rows=1.0 (1954), local_user[local_user]@ip-172-31-8-31.ap-northeast-1.compute.internal
  SELECT isu FROM adding WHERE room_name = 'S' AND time = N FOR UPDATE

Count: 4887  Time=0.00s (0s)  Lock=0.00s (0s)  Rows=13.0 (63531), local_user[local_user]@ip-172-31-8-31.ap-northeast-1.compute.internal
  SELECT * FROM m_item

Count: 55  Time=0.00s (0s)  Lock=0.00s (0s)  Rows=0.0 (0), local_user[local_user]@ip-172-31-8-31.ap-northeast-1.compute.internal
  ROLLBACK

Count: 7255  Time=0.00s (0s)  Lock=0.00s (0s)  Rows=1.0 (7255), local_user[local_user]@ip-172-31-8-31.ap-northeast-1.compute.internal
  SELECT time FROM room_time WHERE room_name = 'S' FOR UPDATE

Count: 16451  Time=0.00s (1s)  Lock=0.00s (0s)  Rows=1.0 (16451), local_user[local_user]@ip-172-31-8-31.ap-northeast-1.compute.internal
  SELECT * FROM m_item WHERE item_id = N

Count: 12142  Time=0.00s (0s)  Lock=0.00s (0s)  Rows=1.0 (12142), local_user[local_user]@ip-172-31-8-31.ap-northeast-1.compute.internal
  SELECT floor(unix_timestamp(current_timestamp(N))*N)

Count: 215  Time=0.00s (0s)  Lock=0.00s (0s)  Rows=0.0 (0), local_user[local_user]@ip-172-31-8-31.ap-northeast-1.compute.internal
  SET NAMES utf8mb4

Count: 7255  Time=0.00s (0s)  Lock=0.00s (0s)  Rows=0.0 (0), local_user[local_user]@ip-172-31-8-31.ap-northeast-1.compute.internal
  START TRANSACTION

Count: 197  Time=0.00s (0s)  Lock=0.00s (0s)  Rows=0.0 (0), local_user[local_user]@ip-172-31-8-31.ap-northeast-1.compute.internal
  #

Count: 195  Time=0.00s (0s)  Lock=0.00s (0s)  Rows=0.0 (0), 0users@0hosts
  administrator command: Quit

Count: 2  Time=0.00s (0s)  Lock=0.00s (0s)  Rows=0.0 (0), 0users@0hosts
  administrator command: Ping
```
