### PR TITLE
チャンネルステータスをsubscribeする感じに再設計

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+go/src/app/app

--- a/go/src/app/game.go
+++ b/go/src/app/game.go
@@ -530,6 +530,59 @@ func calcStatus(currentTime int64, mItems map[int]mItem, addings []Adding, buyin
 	}, nil
 }
 
+var (
+	roomStatusSubscribers      map[string][]*websocket.Conn
+	roomStatusSubscribersMutex = sync.RWMutex{}
+)
+
+func makeRoomStatusProvider(roomName string) {
+	log.Println("makeRoomStatusProvider", roomName)
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			roomStatusSubscribersMutex.RLock()
+			subscribers, ok := roomStatusSubscribers[roomName]
+			roomStatusSubscribersMutex.RUnlock()
+			if !ok || len(subscribers) == 0 {
+				return
+			}
+
+			status, err := getStatus(roomName)
+			if err != nil {
+				log.Println(err)
+				return
+			}
+
+			for _, ws := range subscribers {
+				go func(ws *websocket.Conn) {
+					err = ws.WriteJSON(status)
+					if err != nil {
+						log.Println(err)
+						// TODO: 失敗したらunsubscribe
+						return
+					}
+				}(ws)
+			}
+		}
+	}
+}
+
+func subscribeRoomStatus(roomName string, ws *websocket.Conn) {
+	roomStatusSubscribersMutex.Lock()
+	subscribers, ok := roomStatusSubscribers[roomName]
+	if !ok {
+		// 初回subscribe時のみsubscriptionを作る
+		go makeRoomStatusProvider(roomName)
+	}
+	roomStatusSubscribers[roomName] = append(subscribers, ws)
+	roomStatusSubscribersMutex.Unlock()
+	log.Println("subscribeRoomStatus", roomName, len(subscribers)+1)
+}
+
 func serveGameConn(ws *websocket.Conn, roomName string) {
 	log.Println(ws.RemoteAddr(), "serveGameConn", roomName)
 	defer ws.Close()
@@ -569,8 +622,7 @@ func serveGameConn(ws *websocket.Conn, roomName string) {
 		}
 	}()
 
-	ticker := time.NewTicker(500 * time.Millisecond)
-	defer ticker.Stop()
+	subscribeRoomStatus(roomName, ws)
 
 	for {
 		select {
@@ -607,18 +659,6 @@ func serveGameConn(ws *websocket.Conn, roomName string) {
 				RequestID: req.RequestID,
 				IsSuccess: success,
 			})
-			if err != nil {
-				log.Println(err)
-				return
-			}
-		case <-ticker.C:
-			status, err := getStatus(roomName)
-			if err != nil {
-				log.Println(err)
-				return
-			}
-
-			err = ws.WriteJSON(status)
 			if err != nil {
 				log.Println(err)
 				return

--- a/go/src/app/game.go
+++ b/go/src/app/game.go
@@ -541,6 +541,7 @@ func makeRoomStatusProvider(roomName string) {
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
 
+LOOP:
 	for {
 		select {
 		case <-ticker.C:
@@ -549,12 +550,12 @@ func makeRoomStatusProvider(roomName string) {
 			roomStatusSubscribersMutex.RUnlock()
 			if !ok || len(subscribers) == 0 {
 				log.Println("makeRoomStatusProvider", roomName, "no subscribers")
-				break
+				break LOOP
 			}
 
 			status, err := getStatus(roomName)
 			if err != nil {
-				log.Println(err)
+				log.Println("failed to get status", err)
 				return
 			}
 

--- a/go/src/app/game.go
+++ b/go/src/app/game.go
@@ -607,7 +607,10 @@ func unsubscribeRoomStatus(roomName string, ws *websocket.Conn) {
 
 func serveGameConn(ws *websocket.Conn, roomName string) {
 	log.Println(ws.RemoteAddr(), "serveGameConn", roomName)
-	defer ws.Close()
+	defer func() {
+		ws.Close()
+		unsubscribeRoomStatus(roomName, ws)
+	}()
 
 	status, err := getStatus(roomName)
 	if err != nil {

--- a/go/src/app/game.go
+++ b/go/src/app/game.go
@@ -562,7 +562,7 @@ func makeRoomStatusProvider(roomName string) {
 				go func(ws *websocket.Conn) {
 					err = ws.WriteJSON(status)
 					if err != nil {
-						log.Println(err)
+						log.Println("failed to write json", err)
 						unsubscribeRoomStatus(roomName, ws)
 						return
 					}
@@ -601,6 +601,8 @@ func unsubscribeRoomStatus(roomName string, ws *websocket.Conn) {
 	roomStatusSubscribers[roomName] = newSubscribers
 
 	roomStatusSubscribersMutex.Unlock()
+
+	log.Println("unsubscribeRoomStatus", roomName, len(newSubscribers))
 }
 
 func serveGameConn(ws *websocket.Conn, roomName string) {

--- a/go/src/app/game.go
+++ b/go/src/app/game.go
@@ -592,17 +592,17 @@ func unsubscribeRoomStatus(roomName string, ws *websocket.Conn) {
 		return
 	}
 
-	newSubscribers := []*websocket.Conn{}
+	remainingSubscribers := []*websocket.Conn{}
 	for _, s := range subscribers {
 		if s != ws {
-			newSubscribers = append(newSubscribers, s)
+			remainingSubscribers = append(remainingSubscribers, s)
 		}
 	}
-	roomStatusSubscribers[roomName] = newSubscribers
+	roomStatusSubscribers[roomName] = remainingSubscribers
 
 	roomStatusSubscribersMutex.Unlock()
 
-	log.Println("unsubscribeRoomStatus", roomName, len(newSubscribers))
+	log.Println("unsubscribeRoomStatus", roomName, len(remainingSubscribers))
 }
 
 func serveGameConn(ws *websocket.Conn, roomName string) {

--- a/go/src/app/game.go
+++ b/go/src/app/game.go
@@ -531,7 +531,7 @@ func calcStatus(currentTime int64, mItems map[int]mItem, addings []Adding, buyin
 }
 
 var (
-	roomStatusSubscribers      map[string][]*websocket.Conn
+	roomStatusSubscribers      = map[string][]*websocket.Conn{}
 	roomStatusSubscribersMutex = sync.RWMutex{}
 )
 

--- a/go/src/app/game.go
+++ b/go/src/app/game.go
@@ -548,6 +548,7 @@ func makeRoomStatusProvider(roomName string) {
 			subscribers, ok := roomStatusSubscribers[roomName]
 			roomStatusSubscribersMutex.RUnlock()
 			if !ok || len(subscribers) == 0 {
+				log.Println("makeRoomStatusProvider", roomName, "no subscribers")
 				break
 			}
 

--- a/go/src/app/game.go
+++ b/go/src/app/game.go
@@ -548,7 +548,7 @@ func makeRoomStatusProvider(roomName string) {
 			subscribers, ok := roomStatusSubscribers[roomName]
 			roomStatusSubscribersMutex.RUnlock()
 			if !ok || len(subscribers) == 0 {
-				return
+				break
 			}
 
 			status, err := getStatus(roomName)
@@ -574,11 +574,11 @@ func makeRoomStatusProvider(roomName string) {
 func subscribeRoomStatus(roomName string, ws *websocket.Conn) {
 	roomStatusSubscribersMutex.Lock()
 	subscribers, ok := roomStatusSubscribers[roomName]
+	roomStatusSubscribers[roomName] = append(subscribers, ws)
 	if !ok {
 		// 初回subscribe時のみsubscriptionを作る
 		go makeRoomStatusProvider(roomName)
 	}
-	roomStatusSubscribers[roomName] = append(subscribers, ws)
 	roomStatusSubscribersMutex.Unlock()
 	log.Println("subscribeRoomStatus", roomName, len(subscribers)+1)
 }

--- a/go/src/app/main.go
+++ b/go/src/app/main.go
@@ -61,6 +61,11 @@ func getInitializeHandler(w http.ResponseWriter, r *http.Request) {
 	db.MustExec("TRUNCATE TABLE adding")
 	db.MustExec("TRUNCATE TABLE buying")
 	db.MustExec("TRUNCATE TABLE room_time")
+
+	roomStatusSubscribersMutex.Lock()
+	roomStatusSubscribers = map[string][]*websocket.Conn{}
+	roomStatusSubscribersMutex.Unlock()
+
 	w.WriteHeader(204)
 }
 


### PR DESCRIPTION
refs #1 

現状、ws接続ごとにgoroutineを作り0.5m secごとにgetStatusを呼んでいてN+1が起きている。
ws接続ごとにgetStatus呼ぶのではなく、roomごとにgetStatus呼んだ結果をroom参加者へ配信する形に変更する。